### PR TITLE
Update to remove tox skip

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -77,7 +77,7 @@ setenv =
   # NOTE: value of the `SKIP` env var must not be updated separately
   # NOTE: from changing the pre-commit setup.
   {[testenv]setenv}
-  SKIP = cspell, flake8-rule-candidates, mypy-py310
+  SKIP = flake8-rule-candidates, mypy-py310
 
 [testenv:lint-candidates]
 description = All enforced standards and docstring, spelling and mypy using 3.10


### PR DESCRIPTION
This will remove the skip entry for spell from tox lint.